### PR TITLE
Fix physics hover when moving mouse from `Control` to `Control`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3066,9 +3066,8 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 	if (over != gui.mouse_over) {
 		if (gui.mouse_over) {
 			_drop_mouse_over();
-		} else {
-			_drop_physics_mouseover();
 		}
+		_drop_physics_mouseover();
 
 		gui.mouse_over = over;
 		if (over) {


### PR DESCRIPTION
Previously the case was not considered, that the mouse can be at the same time over a `Control` node and over a `CollisionObject3D`.

Make sure that physics mouseover is dropped when moving from a MouseFilterPass-Control-Node to a MouseFilterStop-Control-Node.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
